### PR TITLE
Change 'and' to 'or'; add commas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,8 @@ Features
 Requirements
 --------------
 
-* Django 1.8, 1.9, 1.10 and 1.11
-* Python 2.7, 3.3, 3.4, 3.5 and 3.6
+* Django 1.8, 1.9, 1.10, or 1.11
+* Python 2.7, 3.3, 3.4, 3.5, or 3.6
 * django-appconf (included in ``install_requires``)
 * pytz (included in ``install_requires``)
 


### PR DESCRIPTION
Change the 'and' in these sentences to 'or' to express that not all versions are needed as requirements.  Only one version is required.

Add a comma before 'or' to improve the serial nature of the list, specifically the last two items.